### PR TITLE
set cursor in ais layer default style instead

### DIFF
--- a/javascript/ais.js
+++ b/javascript/ais.js
@@ -77,7 +77,8 @@ Ais = OpenLayers.Class(Object,{
                     'default':new OpenLayers.Style({
                         externalGraphic:'${graphic}',
                         graphicHeight:'${graphicSize}',
-                        rotation:'${heading}'
+                        rotation:'${heading}',
+                        cursor:'crosshair'
                     },{
                         context:{
                             graphic:function(feature){
@@ -107,10 +108,7 @@ Ais = OpenLayers.Class(Object,{
                                 }
                             }
                         }
-                    }),
-                    'select':{
-                        cursor:'crosshair'
-                    }
+                    })
                 })
             })
         );


### PR DESCRIPTION
Crosshair on hover only works because the passed-in selectControl 
has hover:true. If anyone were to use a click activation strategy with the
select control the cursor would no longer change on hover over AIS markers.
Setting the cursor style in default instead of select should fix this.
