### PR TITLE
Fix for trip planner: allow the browser to display scrollbars on the page

### DIFF
--- a/map-full.css
+++ b/map-full.css
@@ -4,7 +4,6 @@ html,body {
     width: 100%;
     margin: 0;
     padding: 0;
-    overflow: hidden;
     color: #000000;
 }
 


### PR DESCRIPTION
This enables the view of all output from the turn planner.
It is not a realy good solution. The right thing would be to display the scrollbars inside the popup window but if no good idea how to do that.