### PR TITLE
Use https to fetch marinetraffic AIS tiles

### DIFF
--- a/index.php
+++ b/index.php
@@ -842,7 +842,7 @@
                     strategies: [bboxStrategyWikipedia],
                     protocol: poiLayerWikipediaHttp
                 });
-                layer_ais = new OpenLayers.Layer.TMS("Marinetraffic", "http://tiles.marinetraffic.com/ais_helpers/shiptilesingle.aspx?output=png&sat=1&grouping=shiptype&tile_size=512&legends=1&zoom=${z}&X=${x}&Y=${y}",
+                layer_ais = new OpenLayers.Layer.TMS("Marinetraffic", "https://tiles.marinetraffic.com/ais_helpers/shiptilesingle.aspx?output=png&sat=1&grouping=shiptype&tile_size=512&legends=1&zoom=${z}&X=${x}&Y=${y}",
                     { layerId: 13, numZoomLevels: 19, type: 'png', getURL:getTileURLMarine, isBaseLayer:false, displayOutsideMaxExtent:true, tileSize    : new OpenLayers.Size(512,512)
                   });
                 // SatPro


### PR DESCRIPTION
Reduce latency by bypassing the http -> https redirects, using HTTP 2

Check eg
http://tiles.marinetraffic.com/ais_helpers/shiptilesingle.aspx?output=png&sat=1&grouping=shiptype&tile_size=512&legends=1&zoom=10&X=276&Y=184
to see that all these requests are redirected to https.