### PR TITLE
fix links to open port guide website

### DIFF
--- a/map_key_pages/license_de.php
+++ b/map_key_pages/license_de.php
@@ -29,7 +29,7 @@
     </tr>
     <tr>
         <td><img alt="OSM-Logo" src="resources/icons/OpenPortGuideLogo_32.png" height="44" border="0"></td>
-        <td>Alle Wetterinformationen entstammen dem <a href="http://openportguide.org/wiki_/Main_Page" target="_blank">OpenPortGuide-Projekt</a>.</td>
+        <td>Alle Wetterinformationen entstammen dem <a href="http://openportguide.org/index.php/de/" target="_blank">OpenPortGuide-Projekt</a>.</td>
     </tr>
     <tr>
         <td height="5" class="normal" colspan="2">

--- a/map_key_pages/license_en.php
+++ b/map_key_pages/license_en.php
@@ -29,7 +29,7 @@
     </tr>
     <tr>
         <td><img alt="OSM-Logo" src="resources/icons/OpenPortGuideLogo_32.png" height="44" border="0"></td>
-        <td>All weather information is created by the <a href="http://openportguide.org/wiki_/Main_Page" target="_blank">OpenPortGuide-Project</a>.</td>
+        <td>All weather information is created by the <a href="http://openportguide.org/index.php/en/" target="_blank">OpenPortGuide-Project</a>.</td>
     </tr>
     <tr>
         <td height="5" class="normal" colspan="2">


### PR DESCRIPTION
The OpenPortGuide website has changed; this PR updates the links from the license info.