### PR TITLE
trip planner hotfix: close and delete did not work anymore

### DIFF
--- a/javascript/route/NauticalRoute.js
+++ b/javascript/route/NauticalRoute.js
@@ -161,7 +161,7 @@ function NauticalRoute_routeModified(event) {
     NauticalRoute_getPoints(routeTrack);
 }
 
-routeChanged = false;
+let routeChanged = false;
 
 function NauticalRoute_getPoints(points) {
 


### PR DESCRIPTION
@aAXEe, The latest trip planner PR had a bug, unfortunately. Neither the delete nor the close button worked. This PR fixes that. Sorry for the oversight.