### PR TITLE
hide the checkbox for elevation profile

### DIFF
--- a/classes/topmenu.inc
+++ b/classes/topmenu.inc
@@ -32,7 +32,8 @@
                 <li onClick="showSport()"><a><input type="checkbox" id="checkLayerSport">&nbsp;Sport</a></li>
                 <li onClick="showBingAerial()"><a><input type="checkbox" id="checkLayerBingAerial">&nbsp;<?=$t->tr("bingaerial")?></a></li>
                 <li onClick="showGridWGS()"><a><input type="checkbox" id="checkLayerGridWGS">&nbsp;<?=$t->tr("coordinateGrid")?></a></li>
-                <li onClick="showElevationProfile()"><a><input type="checkbox" id="checkLayerElevationProfile">&nbsp;<?=$t->tr("elevationProfile")?></a></li>
+                <!-- remove elevation profile until we find another server that works -->
+                <li style="display:none" onClick="showElevationProfile()"><a><input type="checkbox" id="checkLayerElevationProfile">&nbsp;<?=$t->tr("elevationProfile")?></a></li>
                 <li onClick="showGebcoDepth()"><a><input type="checkbox" id="checkLayerGebcoDepth">&nbsp;<?=$t->tr("gebcoDepth")?></a></li>
                 <li onClick="showWikipediaLinks(false)">
                     <a><input type="checkbox" id="checkLayerWikipedia">&nbsp;Wikipedia-Links</a>


### PR DESCRIPTION
This hides the checkbox for display of the elevation data and therefore fixes #123 (sort of) until we find another tile server for elevation data tiles.