### PR TITLE
move rose up and left to not conflict with other UI elements

### DIFF
--- a/map-full.css
+++ b/map-full.css
@@ -39,8 +39,8 @@ img {
 /* geo north image is 301x301, mag north image is 200x200 */
 #compassRose {
     position: absolute;
-    bottom: 25px;
-    right:  0px;
+    bottom: 2.5em;
+    right:  18px;
     width: 261px; height: 261px;
     visibility:hidden;
 }


### PR DESCRIPTION
This moves the compass rose out of the way of other UI elements such as the "permalink" and the overview page. Note that there still is a bug where the rose overlays the overview -- that would be subject of another bugfix (and is not straightforward to fix).