### PR TITLE
bugfix: compass pointed in the wrong direction

### DIFF
--- a/javascript/mag_deviation.js
+++ b/javascript/mag_deviation.js
@@ -40,7 +40,7 @@ function setMagdev(p) {
     let deviation = myGeoMagNow.dec;
     let change = (myGeoMagThen.dec-myGeoMagNow.dec) / nextyear;
 
-    document.getElementById('magCompassRose').style.transform = 'rotate('+(-deviation).toFixed(1)+'deg)';
+    document.getElementById('magCompassRose').style.transform = 'rotate('+deviation.toFixed(1)+'deg)';
     // EXAMPLE
     // VAR 3.5°5'E (2015)
     // ANNUAL DECREASE 8'


### PR DESCRIPTION
The magnetic compass points in the wrong direction. For easterly variation, it should point east (i.e. right) or north.