### PR TITLE
replace ip address of open sea map osm tileserver by url t2.opensemap…

### DIFF
--- a/index.php
+++ b/index.php
@@ -128,7 +128,7 @@
 
               if (OsmTileServer == "BRAVO")
               {
-                retv=['http://213.209.102.17/tile/${z}/${x}/${y}.png'];
+                retv=['http://t2.openseamap.org/tile/${z}/${x}/${y}.png'];
               }
               else{
                 retv=['http://a.tile.openstreetmap.org/${z}/${x}/${y}.png',


### PR DESCRIPTION
fix ip address makes problems since nginx proxy with https support is used on bravo