### PR TITLE
Fix php bugs related to translation

### DIFF
--- a/classes/Translation.php
+++ b/classes/Translation.php
@@ -116,7 +116,7 @@ class Translation {
      * Parsed die vom Browser gesendeten bevorzugten Sprachen und gibt sie als Array mit Gewichtigkeit zurück
      */
     function getHttpPreferredLanguages() {
-        $list = $_SERVER['HTTP_ACCEPT_LANGUAGE'];
+        $list = $_SERVER['HTTP_ACCEPT_LANGUAGE'] ?? 'en';
         $preferredLanguages = array();
         $array = explode(",",$list);
         foreach ($array as $key => $value) {

--- a/index.php
+++ b/index.php
@@ -1543,7 +1543,7 @@
                         </li>
                         <!-- <li>
                             <input type="checkbox" id="checkLayerSatPro" onClick="toggleLayer(layer_satpro);">
-                            <label for="checkLayerSatPro"><?=$t->tr("satPro")?></label>
+                            <label for="checkLayerSatPro"><?=$t->tr("satpro")?></label>
                         </li> -->
                         <li>
                             <input type="checkbox" id="checkLayerWikipedia" onClick="toggleLayer(layer_wikipedia);"/>


### PR DESCRIPTION
Some clients/user agents don't send their preferred language; this needs to be handled in the code by using a default. Also, the key for accessing the translation for the satellite layer used incorrect camel casing.